### PR TITLE
canvierte SQL a Minusculas

### DIFF
--- a/src/empdsp.sqlrpgle
+++ b/src/empdsp.sqlrpgle
@@ -42,22 +42,22 @@ Dcl-Proc EMP_Load;
 
   Dcl-S lSuccess Ind Inz(*On);
 
-  EXEC SQL
-    SELECT
-      EMPNO,
-      FIRSTNME,
-      MIDINIT,
-      LASTNAME,
-      WORKDEPT,
-      PHONENO,
-      JOB,
-      SEX,
-      SALARY,
-      BONUS,
-      COMM
-    INTO :EMP_DS
-    FROM SAMPLE/EMPLOYEE
-    WHERE EMPNO = :PEMP;
+  exec sql
+    select
+      empno,
+      firstnme,
+      midinit,
+      lastname,
+      workdept,
+      phoneno,
+      job,
+      sex,
+      salary,
+      bonus,
+      comm
+    into :emp_ds
+    from sample/employee
+    where empno = :pemp;
 
   lSuccess = (SQLSTATE = '00000');
 

--- a/src/empnew.sqlrpgle
+++ b/src/empnew.sqlrpgle
@@ -29,22 +29,22 @@ Return;
 dcl-proc emp_create;
   dcl-s lexit ind inz(*off);
 
-  DOW (LEXIT = *OFF);
-    EXFMT NEWEMP;
+  dow (lexit = *off);
+    exfmt newemp;
 
-    SELECT;
-      WHEN (*IN12);
-        LEXIT = *ON;
-      OTHER;
-        IF (EMP_VALIDATEINPUT());
-          //CREATE NEW EMPLOYEE
-          EMP_CREATERECORD();
-          LEXIT = *ON;
-        ENDIF;
-    ENDSL;
-  ENDDO;
+    select;
+      when (*in12);
+        lexit = *on;
+      other;
+        if (emp_validateinput());
+          //create new employee
+          emp_createrecord();
+          lexit = *on;
+        endif;
+    endsl;
+  enddo;
 
-END-PROC;
+end-proc;
 
 Dcl-Proc EMP_ValidateInput;
   //Returns true if valid.


### PR DESCRIPTION
he cabiado SQL a minuscuala para alinear a la politica de gobierno para scripts de automatizacion de plataformas centrales.